### PR TITLE
Exclude target folder in Item provider views

### DIFF
--- a/src/views/DataMappingsProvider.ts
+++ b/src/views/DataMappingsProvider.ts
@@ -21,7 +21,7 @@ export class DataMappingsProvider implements vscode.TreeDataProvider<vscode.Tree
     readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
     private static readonly FILE_PATTERN = '**/*.xsl';
-    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**}';
+    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/target/**}';
 
     private fileWatcher: vscode.FileSystemWatcher;
 

--- a/src/views/IntegrationsProvider.ts
+++ b/src/views/IntegrationsProvider.ts
@@ -23,7 +23,7 @@ export class IntegrationsProvider implements TreeDataProvider<TreeItem> {
 	readonly onDidChangeTreeData: Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
 	private static readonly FILE_PATTERN = '{**/*.camel.yaml,**/*.kamelet.yaml,**/*-pipe.yaml}';
-	private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**}';
+	private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/target/**}';
 	private fileWatcher: FileSystemWatcher;
 
 	constructor() {

--- a/src/views/OpenApiProvider.ts
+++ b/src/views/OpenApiProvider.ts
@@ -23,7 +23,7 @@ export class OpenApiProvider implements TreeDataProvider<TreeItem> {
     readonly onDidChangeTreeData: Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
     private static readonly FILE_PATTERN = '**/*.{yaml,json}';
-    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/*.camel.yaml}';
+    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/*.camel.yaml,**/target/**}';
     private fileWatcher: FileSystemWatcher;
 
     constructor() {

--- a/src/views/TestsProvider.ts
+++ b/src/views/TestsProvider.ts
@@ -21,7 +21,7 @@ export class TestsProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
     readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
     private static readonly FILE_PATTERN = '**/*.{it.yaml,test.yaml}';
-    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**}';
+    private static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/target/**}';
 
     private fileWatcher: vscode.FileSystemWatcher;
 


### PR DESCRIPTION
it will avoid to have the same file visible two times when a Maven project is used